### PR TITLE
Fix: Identify multiple ports of a single USB Devices using MI ID

### DIFF
--- a/src/USBWatcher.Core/USBWatcherCore.cs
+++ b/src/USBWatcher.Core/USBWatcherCore.cs
@@ -9,7 +9,8 @@ namespace USBWatcher.Core
         string PID,
         string PortName,
         string SerialNumber,
-        string Manufacturer
+        string Manufacturer,
+        string MI
     );
 
     public class USBWatcherCore
@@ -59,7 +60,8 @@ namespace USBWatcher.Core
                 d.PID,
                 d.PortName,
                 d.SerialNumber,
-                d.Manufacturer
+                d.Manufacturer,
+                d.MI
             )).ToList().AsReadOnly();
         }
 

--- a/src/USBWatcher.Core/UsbDevice.cs
+++ b/src/USBWatcher.Core/UsbDevice.cs
@@ -31,7 +31,7 @@ namespace USBWatcher.Core
         public string PortName { get; set; }
         public string SerialNumber { get; set; }
         public string Manufacturer { get; set; }
-        public bool AutoSetName { get; set; } = false;
+        public string MI { get; set; }
         private string GetFriendlyName(string deviceId)
         {
             string RegKey = DeviceRegKey;
@@ -97,6 +97,11 @@ namespace USBWatcher.Core
             return serial_number;
         }
 
+        private string GetMI(string deviceId)
+        {
+            return ParseDeviceID(@"(MI_)(\d{2})", deviceId);
+        }
+
         public UsbDevice(string deviceId)
         {
             string[] patterns = new string[]
@@ -116,6 +121,7 @@ namespace USBWatcher.Core
                     _friendlyName = GetFriendlyName(deviceId);
                     VID = GetVID(deviceId);
                     PID = GetPID(deviceId);
+                    MI = GetMI(deviceId);
                     Manufacturer = GetManufacturer(deviceId);
                     /* Extract serial number from device ID in case of FTDI Devices */
                     if (deviceId.Contains("FTDI"))

--- a/src/USBWatcher.WinForms/Main.cs
+++ b/src/USBWatcher.WinForms/Main.cs
@@ -58,16 +58,17 @@ namespace USBWatcher
 
             foreach (UsbDeviceRecord usbdev in UsbDevicesList)
             {
+                string subID = string.IsNullOrEmpty(usbdev.SerialNumber) ? usbdev.MI : usbdev.SerialNumber;
                 string[] DevInfo = new string[]
                 {
                     usbdev.FriendlyName,
                     usbdev.PortName,
                     usbdev.VID,
                     usbdev.PID,
-                    usbdev.SerialNumber,
+                    subID
                 };
 
-                var storedFriendlyName = Settings.GetStoredDeviceName(usbdev.VID, usbdev.PID, usbdev.SerialNumber);
+                var storedFriendlyName = Settings.GetStoredDeviceName(usbdev.VID, usbdev.PID, subID);
                 if (!string.IsNullOrEmpty(storedFriendlyName))
                 {
                     usb_watcher.SetUSBDeviceFriendlyName(usbdev.PortName, storedFriendlyName);


### PR DESCRIPTION
Fix #9

if a USB Devices has multiple serial ports without a serial number, let's us MI ID to distinguish between ports.